### PR TITLE
fix: handle null values for strlen() and htmlspecialchars() calls

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -10,8 +10,8 @@
 Plugin Name: Fieldmanager
 Plugin URI: https://github.com/alleyinteractive/wordpress-fieldmanager
 Description: Add fields to content types programatically.
-Author: Austin Smith, Matthew Boynes
-Version: 1.1.0-beta.1
+Author: Austin Smith, Matthew Boynes, Immediate Media Co
+Version: 2023.11.03.7
 Author URI: http://www.alleyinteractive.com/
 */
 

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -789,8 +789,7 @@ abstract class Fieldmanager_Field {
 				if ( is_array( $value ) ) {
 					return ! empty( $value );
 				} else {
-					$value = $value ?? '';
-					return strlen( $value );
+					return strlen( $value ?? '' );
 				}
 			} );
 			// reindex the array after removing empty values

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -789,6 +789,7 @@ abstract class Fieldmanager_Field {
 				if ( is_array( $value ) ) {
 					return ! empty( $value );
 				} else {
+					$value = $value ?? '';
 					return strlen( $value );
 				}
 			} );

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -86,15 +86,15 @@ abstract class Fieldmanager_Context {
 		$echo = isset( $args['echo'] ) ? $args['echo'] : true;
 
 		// handle case where null values are passed down to prevent error in htmlspecialchars() in 8.1
-		if ($data !== null) {
-			array_walk_recursive($data, static function(&$value){
-				if (is_null($value)) {
-					$value = '';
-				}
-			});
-		} else {
+		if ($data === null) {
 			return null;
 		}
+
+		array_walk_recursive($data, static function(&$value) {
+			if (is_null($value)) {
+				$value = '';
+			}
+		});
 
 		$nonce = wp_nonce_field( 'fieldmanager-save-' . $this->fm->name, 'fieldmanager-' . $this->fm->name . '-nonce', true, false );
 		$field = $this->fm->element_markup( $data );

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -85,6 +85,17 @@ abstract class Fieldmanager_Context {
 		$data = array_key_exists( 'data', $args ) ? $args['data'] : null;
 		$echo = isset( $args['echo'] ) ? $args['echo'] : true;
 
+		// handle case where null values are passed down to prevent error in htmlspecialchars() in 8.1
+		if ($data !== null) {
+			array_walk_recursive($data, static function(&$value){
+				if (is_null($value)) {
+					$value = '';
+				}
+			});
+		} else {
+			return null;
+		}
+
 		$nonce = wp_nonce_field( 'fieldmanager-save-' . $this->fm->name, 'fieldmanager-' . $this->fm->name . '-nonce', true, false );
 		$field = $this->fm->element_markup( $data );
 		if ( $echo ) {


### PR DESCRIPTION
Fix for htmlspecialchars() error in 8.1
This fix prevents null values from being passed down into `wp-core` functions where `htmlspecialcharacters()` is called. This is particularly the case when a new post is created and we send through a WP_Post object that then is translated into having a description of NULL. The array walk just tidies the values to ensure that we are not passing empty to any core functions that now do not allow null values.

Fix for strlen()
Simple fix to prevent strlen being passed a null value that was causing errors to be thrown.