### PR TITLE
fix: add type protection for array_walk

### DIFF
--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -90,11 +90,13 @@ abstract class Fieldmanager_Context {
 			return null;
 		}
 
-		array_walk_recursive($data, static function(&$value) {
-			if (is_null($value)) {
-				$value = '';
-			}
-		});
+		if (is_array($data)) {
+			array_walk_recursive($data, static function (&$value) {
+				if (is_null($value)) {
+					$value = '';
+				}
+			});
+		}
 
 		$nonce = wp_nonce_field( 'fieldmanager-save-' . $this->fm->name, 'fieldmanager-' . $this->fm->name . '-nonce', true, false );
 		$field = $this->fm->element_markup( $data );


### PR DESCRIPTION
Fix to protect the array walk cleanup from non array values. This method receives a very mixed bag to pass down to core functions. This should prevent a critical error being thrown when passing a non array by ref to `array_walk_recursive()`.